### PR TITLE
ci: Add macOS build and test workflow

### DIFF
--- a/.github/workflows/linux-package-build.yml
+++ b/.github/workflows/linux-package-build.yml
@@ -1,0 +1,51 @@
+name: Build and Test on Linux
+
+on:
+  push:
+    branches: [ '*' ]
+  pull_request:
+    branches: [ '*' ]
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest  # Correct Linux runner
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"  # Adjust if necessary
+
+      - name: Install dependencies
+        run: |
+          python3 -m ensurepip --default-pip
+          python3 -m pip install --upgrade pip poetry
+
+      - name: Verify Poetry installation
+        run: poetry --version
+
+      - name: Build the package
+        run: |
+          if [[ -f "./build.sh" ]]; then
+            chmod +x ./build.sh
+            ./build.sh
+          else
+            echo "Error: build.sh not found!"
+            exit 1
+          fi
+
+      - name: Verify executable
+        run: |
+          export TERM=xterm  # Set a default terminal
+          if ! command -v commi &>/dev/null; then
+            echo "Error: commi executable was not found in PATH!"
+            echo "Checking alternative locations..."
+            find . -name "commi" -type f || echo "No executable found."
+            exit 1
+          fi
+          echo "✅ Commi executable found! Running a test..."
+          commi --help || { echo "Error: Executable failed to run!"; exit 1; }

--- a/.github/workflows/linux-package-build.yml
+++ b/.github/workflows/linux-package-build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest  # Correct Linux runner
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.12"  # Adjust if necessary
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/macos-package-build.yml
+++ b/.github/workflows/macos-package-build.yml
@@ -1,0 +1,43 @@
+name: Build and Test on macOS
+
+on:
+  push:
+    branches: [ '*' ]
+  pull_request:
+    branches: [ '*' ]
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"  # Adjust to your required version
+
+      - name: Install dependencies
+        run: |
+          python3 -m ensurepip --default-pip
+          python3 -m pip install --upgrade pip poetry
+
+      - name: Verify Poetry installation
+        run: poetry --version
+
+      - name: Build the package
+        run: chmod +x ./build.sh && ./build.sh
+
+      - name: Verify executable
+        run: |
+          if ! command -v commi &>/dev/null; then
+            echo "Error: commi executable was not found!"
+            exit 1
+          fi
+          echo "Commi executable found, running a test..."
+          commi --help || { echo "Error: Executable failed to run!"; exit 1; }
+
+      - name: Print success message
+        run: echo "✅ Build and execution successful!"

--- a/.github/workflows/macos-package-build.yml
+++ b/.github/workflows/macos-package-build.yml
@@ -32,12 +32,10 @@ jobs:
 
       - name: Verify executable
         run: |
+          export TERM=xterm  # Set a default terminal
           if ! command -v commi &>/dev/null; then
             echo "Error: commi executable was not found!"
             exit 1
           fi
           echo "Commi executable found, running a test..."
           commi --help || { echo "Error: Executable failed to run!"; exit 1; }
-
-      - name: Print success message
-        run: echo "✅ Build and execution successful!"

--- a/.github/workflows/macos-package-build.yml
+++ b/.github/workflows/macos-package-build.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.12"  # Adjust to your required version
+          python-version: "3.9"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/poetry-build.yml
+++ b/.github/workflows/poetry-build.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Poetry Build
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Commi is an AI-powered tool that automatically generates Git commit messages bas
 
 ### Build from source
 
+**Requirements:**
+- Python 3.12 or higher
+
 To install **Commi** manually, follow these steps:
 
 1. Clone the repository:
@@ -46,6 +49,9 @@ To install **Commi** manually, follow these steps:
    ```
 
 ### Using pip
+
+**Requirements:**
+- Python 3.12 or higher
 
 You can install **Commi** using pip:
 

--- a/build.sh
+++ b/build.sh
@@ -10,6 +10,8 @@ YELLOW='\033[0;33m'
 CYAN='\033[0;36m'
 RESET='\033[0m'
 
+export TERM=xterm-color
+
 # Function to print Commi ASCII art with optional coloring
 print_commi_ascii() {
     echo -e "${CYAN}"

--- a/build.sh
+++ b/build.sh
@@ -65,10 +65,6 @@ check_python_version() {
         echo -e "${CYAN}On Linux (Debian-based), run:${RESET}"
         echo -e "  sudo apt update && sudo apt install python3"
         echo ""
-        if ! ask_confirmation "Do you want to continue anyway?"; then
-            echo -e "${RED}Installation aborted.${RESET}"
-            exit 1
-        fi
     fi
 }
 


### PR DESCRIPTION
- Added a new GitHub Actions workflow for building and testing on macOS.
- Renamed the existing build workflow to `poetry-build`