### PR TITLE
feat: Add version checking and auto-update functionality

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+exclude = __init__.py,node_modules
+max-line-length = 250

--- a/commi/cmd.py
+++ b/commi/cmd.py
@@ -3,6 +3,7 @@ import requests
 import json
 import argparse
 import sys
+import subprocess
 from datetime import datetime, timedelta
 
 class CommiCommands:
@@ -10,7 +11,9 @@ class CommiCommands:
     VERSION_CACHE_EXPIRY = timedelta(days=1)
 
     def __init__(self):
-        version = self.get_version()
+        self.installed_version = self.get_installed_version()
+        self.latest_version = self.get_latest_version()
+        
         self.parser = argparse.ArgumentParser(
             description=(
                 "AI-powered Git commit message generator using Gemini AI.\n\n"
@@ -19,17 +22,18 @@ class CommiCommands:
                 "- Blank line separating summary from body\n"
                 "- Detailed explanatory text wrapped at 72 characters\n"
                 "- Use bullet points for multiple changes"
-                f"\nVersion: {version}"
+                f"\nVersion: {self.installed_version}"
             ),
             formatter_class=argparse.RawDescriptionHelpFormatter,
         )
-        self.parser.add_argument("--version", action="version", version=version)
+        self.parser.add_argument("--version", action="version", version=self.installed_version)
         self.parser.add_argument("--repo", help="Path to Git repository (defaults to current directory)")
         self.parser.add_argument("--api-key", help="Gemini AI API key (or set GEMINI_API_KEY env var)")
         self.parser.add_argument("--cached", action="store_true", help="Use staged changes only")
         self.parser.add_argument("--copy", action="store_true", help="Copy message to clipboard")
         self.parser.add_argument("--commit", action="store_true", help="Auto commit with generated message")
         self.parser.add_argument("--co-author", metavar="EMAIL", help="Add a co-author to the commit")
+        self.parser.add_argument("--update", action="store_true", help="Update Commi to the latest version")
 
         self.args = self.parser.parse_args()
 
@@ -39,7 +43,20 @@ class CommiCommands:
             sys.exit(0)
         return self.args
 
-    def get_version(self):
+    def get_installed_version(self):
+        """Get the installed version from pyproject.toml"""
+        try:
+            import toml
+            pyproject_path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "pyproject.toml")
+            with open(pyproject_path, "r") as f:
+                pyproject = toml.load(f)
+                return pyproject["tool"]["poetry"]["version"]
+        except Exception as e:
+            print(f"Warning: Failed to get installed version: {e}")
+            return "0.0.0"  # Default if fetch fails
+            
+    def get_latest_version(self):
+        """Get the latest version from GitHub releases"""
         # Check if version is cached and not expired
         if os.path.exists(self.VERSION_CACHE_FILE):
             with open(self.VERSION_CACHE_FILE, "r") as f:
@@ -55,12 +72,47 @@ class CommiCommands:
         try:
             resp = requests.get("https://api.github.com/repos/Mahmoud-Emad/commi/releases/latest", timeout=5)
             if resp.status_code == 200:
-                version = resp.json()["tag_name"]
+                latest_version = resp.json()["tag_name"]
                 # Cache it
                 with open(self.VERSION_CACHE_FILE, "w") as f:
-                    json.dump({"version": version, "fetched_at": datetime.now().isoformat()}, f)
-                return version
+                    json.dump({"version": latest_version, "fetched_at": datetime.now().isoformat()}, f)
+                return latest_version
         except Exception as e:
             print("Warning: Failed to fetch latest version:", e)
 
         return "0.0.0"  # Default if fetch fails
+        
+    def is_update_available(self):
+        """Check if an update is available"""
+        try:
+            from packaging import version
+            return version.parse(self.latest_version) > version.parse(self.installed_version)
+        except Exception:
+            return False
+            
+    def update_binary(self):
+        """Update the binary to the latest version"""
+        try:
+            print(f"Updating Commi from {self.installed_version} to {self.latest_version}...")
+            
+            # Download the latest release binary
+            release_url = f"https://github.com/Mahmoud-Emad/commi/releases/download/{self.latest_version}/commi"
+            temp_binary = "/tmp/commi_new"
+            
+            # Download the binary
+            subprocess.run(["curl", "-L", release_url, "-o", temp_binary], check=True)
+            
+            # Make it executable
+            subprocess.run(["chmod", "+x", temp_binary], check=True)
+            
+            # Get the current binary path
+            current_binary = subprocess.check_output(["which", "commi"]).decode().strip()
+            
+            # Replace the current binary with the new one
+            subprocess.run(["sudo", "mv", temp_binary, current_binary], check=True)
+            
+            print(f"Successfully updated Commi to version {self.latest_version}!")
+            return True
+        except Exception as e:
+            print(f"Error updating Commi: {e}")
+            return False

--- a/commi/cmd.py
+++ b/commi/cmd.py
@@ -1,9 +1,16 @@
+import os
+import requests
+import json
 import argparse
 import sys
-
+from datetime import datetime, timedelta
 
 class CommiCommands:
+    VERSION_CACHE_FILE = os.path.expanduser("~/.commi_version")
+    VERSION_CACHE_EXPIRY = timedelta(days=1)
+
     def __init__(self):
+        version = self.get_version()
         self.parser = argparse.ArgumentParser(
             description=(
                 "AI-powered Git commit message generator using Gemini AI.\n\n"
@@ -12,49 +19,48 @@ class CommiCommands:
                 "- Blank line separating summary from body\n"
                 "- Detailed explanatory text wrapped at 72 characters\n"
                 "- Use bullet points for multiple changes"
+                f"\nVersion: {version}"
             ),
             formatter_class=argparse.RawDescriptionHelpFormatter,
         )
+        self.parser.add_argument("--version", action="version", version=version)
+        self.parser.add_argument("--repo", help="Path to Git repository (defaults to current directory)")
+        self.parser.add_argument("--api-key", help="Gemini AI API key (or set GEMINI_API_KEY env var)")
+        self.parser.add_argument("--cached", action="store_true", help="Use staged changes only")
+        self.parser.add_argument("--copy", action="store_true", help="Copy message to clipboard")
+        self.parser.add_argument("--commit", action="store_true", help="Auto commit with generated message")
+        self.parser.add_argument("--co-author", metavar="EMAIL", help="Add a co-author to the commit")
 
-        self.parser.add_argument(
-            "--repo", help="Path to Git repository (defaults to current directory)"
-        )
-        self.parser.add_argument(
-            "--api-key",
-            help="Gemini AI API key (can also be set via GEMINI_API_KEY environment variable)",
-        )
-        self.parser.add_argument(
-            "--cached",
-            action="store_true",
-            help="Generate message from staged changes only (git diff --cached)",
-        )
-        self.parser.add_argument(
-            "--copy",
-            action="store_true",
-            help="Copy the generated message to clipboard",
-        )
-        self.parser.add_argument(
-            "--commit",
-            action="store_true",
-            help="Automatically commit the changes with the generated message",
-        )
-        self.parser.add_argument(
-            "--co-author",
-            type=str,
-            metavar="EMAIL",
-            help="Add a co-author to the commit (format: email@example.com)",
-        )
-
-        # Parse the arguments
         self.args = self.parser.parse_args()
 
     def get_args(self):
-        """Parse and return command line arguments."""
-        args = self.parser.parse_args()
-
-        # Print help if no arguments provided
         if len(sys.argv) == 1:
             self.parser.print_help()
             sys.exit(0)
+        return self.args
 
-        return args
+    def get_version(self):
+        # Check if version is cached and not expired
+        if os.path.exists(self.VERSION_CACHE_FILE):
+            with open(self.VERSION_CACHE_FILE, "r") as f:
+                try:
+                    cache = json.load(f)
+                    cached_time = datetime.fromisoformat(cache.get("fetched_at"))
+                    if datetime.now() - cached_time < self.VERSION_CACHE_EXPIRY:
+                        return cache.get("version")
+                except Exception:
+                    pass  # In case of JSON error, fall back to fetching again
+
+        # Fetch from GitHub Releases API
+        try:
+            resp = requests.get("https://api.github.com/repos/Mahmoud-Emad/commi/releases/latest", timeout=5)
+            if resp.status_code == 200:
+                version = resp.json()["tag_name"]
+                # Cache it
+                with open(self.VERSION_CACHE_FILE, "w") as f:
+                    json.dump({"version": version, "fetched_at": datetime.now().isoformat()}, f)
+                return version
+        except Exception as e:
+            print("Warning: Failed to fetch latest version:", e)
+
+        return "0.0.0"  # Default if fetch fails

--- a/commi/cmd.py
+++ b/commi/cmd.py
@@ -6,6 +6,7 @@ import sys
 import subprocess
 from datetime import datetime, timedelta
 
+
 class CommiCommands:
     VERSION_CACHE_FILE = os.path.expanduser("~/.commi_version")
     VERSION_CACHE_EXPIRY = timedelta(days=1)
@@ -13,7 +14,7 @@ class CommiCommands:
     def __init__(self):
         self.installed_version = self.get_installed_version()
         self.latest_version = self.get_latest_version()
-        
+
         self.parser = argparse.ArgumentParser(
             description=(
                 "AI-powered Git commit message generator using Gemini AI.\n\n"
@@ -26,14 +27,30 @@ class CommiCommands:
             ),
             formatter_class=argparse.RawDescriptionHelpFormatter,
         )
-        self.parser.add_argument("--version", action="version", version=self.installed_version)
-        self.parser.add_argument("--repo", help="Path to Git repository (defaults to current directory)")
-        self.parser.add_argument("--api-key", help="Gemini AI API key (or set GEMINI_API_KEY env var)")
-        self.parser.add_argument("--cached", action="store_true", help="Use staged changes only")
-        self.parser.add_argument("--copy", action="store_true", help="Copy message to clipboard")
-        self.parser.add_argument("--commit", action="store_true", help="Auto commit with generated message")
-        self.parser.add_argument("--co-author", metavar="EMAIL", help="Add a co-author to the commit")
-        self.parser.add_argument("--update", action="store_true", help="Update Commi to the latest version")
+        self.parser.add_argument(
+            "--version", action="version", version=self.installed_version
+        )
+        self.parser.add_argument(
+            "--repo", help="Path to Git repository (defaults to current directory)"
+        )
+        self.parser.add_argument(
+            "--api-key", help="Gemini AI API key (or set GEMINI_API_KEY env var)"
+        )
+        self.parser.add_argument(
+            "--cached", action="store_true", help="Use staged changes only"
+        )
+        self.parser.add_argument(
+            "--copy", action="store_true", help="Copy message to clipboard"
+        )
+        self.parser.add_argument(
+            "--commit", action="store_true", help="Auto commit with generated message"
+        )
+        self.parser.add_argument(
+            "--co-author", metavar="EMAIL", help="Add a co-author to the commit"
+        )
+        self.parser.add_argument(
+            "--update", action="store_true", help="Update Commi to the latest version"
+        )
 
         self.args = self.parser.parse_args()
 
@@ -47,14 +64,18 @@ class CommiCommands:
         """Get the installed version from pyproject.toml"""
         try:
             import toml
-            pyproject_path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "pyproject.toml")
+
+            pyproject_path = os.path.join(
+                os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                "pyproject.toml",
+            )
             with open(pyproject_path, "r") as f:
                 pyproject = toml.load(f)
                 return pyproject["tool"]["poetry"]["version"]
         except Exception as e:
             print(f"Warning: Failed to get installed version: {e}")
             return "0.0.0"  # Default if fetch fails
-            
+
     def get_latest_version(self):
         """Get the latest version from GitHub releases"""
         # Check if version is cached and not expired
@@ -70,47 +91,63 @@ class CommiCommands:
 
         # Fetch from GitHub Releases API
         try:
-            resp = requests.get("https://api.github.com/repos/Mahmoud-Emad/commi/releases/latest", timeout=5)
+            resp = requests.get(
+                "https://api.github.com/repos/Mahmoud-Emad/commi/releases/latest",
+                timeout=5,
+            )
             if resp.status_code == 200:
                 latest_version = resp.json()["tag_name"]
                 # Cache it
                 with open(self.VERSION_CACHE_FILE, "w") as f:
-                    json.dump({"version": latest_version, "fetched_at": datetime.now().isoformat()}, f)
+                    json.dump(
+                        {
+                            "version": latest_version,
+                            "fetched_at": datetime.now().isoformat(),
+                        },
+                        f,
+                    )
                 return latest_version
         except Exception as e:
             print("Warning: Failed to fetch latest version:", e)
 
         return "0.0.0"  # Default if fetch fails
-        
+
     def is_update_available(self):
         """Check if an update is available"""
         try:
             from packaging import version
-            return version.parse(self.latest_version) > version.parse(self.installed_version)
+
+            return version.parse(self.latest_version) > version.parse(
+                self.installed_version
+            )
         except Exception:
             return False
-            
+
     def update_binary(self):
         """Update the binary to the latest version"""
         try:
-            print(f"Updating Commi from {self.installed_version} to {self.latest_version}...")
-            
+            print(
+                f"Updating Commi from {self.installed_version} to {self.latest_version}..."
+            )
+
             # Download the latest release binary
             release_url = f"https://github.com/Mahmoud-Emad/commi/releases/download/{self.latest_version}/commi"
             temp_binary = "/tmp/commi_new"
-            
+
             # Download the binary
             subprocess.run(["curl", "-L", release_url, "-o", temp_binary], check=True)
-            
+
             # Make it executable
             subprocess.run(["chmod", "+x", temp_binary], check=True)
-            
+
             # Get the current binary path
-            current_binary = subprocess.check_output(["which", "commi"]).decode().strip()
-            
+            current_binary = (
+                subprocess.check_output(["which", "commi"]).decode().strip()
+            )
+
             # Replace the current binary with the new one
             subprocess.run(["sudo", "mv", temp_binary, current_binary], check=True)
-            
+
             print(f"Successfully updated Commi to version {self.latest_version}!")
             return True
         except Exception as e:

--- a/commi/run.py
+++ b/commi/run.py
@@ -145,6 +145,20 @@ def main():
     try:
         commi_commands = CommiCommands()
         args = commi_commands.get_args()
+        
+        # Handle update command
+        if args.update:
+            if commi_commands.is_update_available():
+                LOGGER.info(f"Update available: {commi_commands.installed_version} -> {commi_commands.latest_version}")
+                commi_commands.update_binary()
+            else:
+                LOGGER.info(f"You are already using the latest version: {commi_commands.installed_version}")
+            return
+            
+        # Check for updates and notify user
+        if commi_commands.is_update_available():
+            LOGGER.info(f"A new version of Commi is available: {commi_commands.latest_version}")
+            LOGGER.info("Run 'commi --update' to update to the latest version.")
 
         # Load and validate configuration
         COMMI_API_KEY, MODEL_NAME = load_configuration(args)

--- a/commi/run.py
+++ b/commi/run.py
@@ -145,19 +145,25 @@ def main():
     try:
         commi_commands = CommiCommands()
         args = commi_commands.get_args()
-        
+
         # Handle update command
         if args.update:
             if commi_commands.is_update_available():
-                LOGGER.info(f"Update available: {commi_commands.installed_version} -> {commi_commands.latest_version}")
+                LOGGER.info(
+                    f"Update available: {commi_commands.installed_version} -> {commi_commands.latest_version}"
+                )
                 commi_commands.update_binary()
             else:
-                LOGGER.info(f"You are already using the latest version: {commi_commands.installed_version}")
+                LOGGER.info(
+                    f"You are already using the latest version: {commi_commands.installed_version}"
+                )
             return
-            
+
         # Check for updates and notify user
         if commi_commands.is_update_available():
-            LOGGER.info(f"A new version of Commi is available: {commi_commands.latest_version}")
+            LOGGER.info(
+                f"A new version of Commi is available: {commi_commands.latest_version}"
+            )
             LOGGER.info("Run 'commi --update' to update to the latest version.")
 
         # Load and validate configuration

--- a/poetry.lock
+++ b/poetry.lock
@@ -1030,6 +1030,17 @@ files = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.10.2"
+description = "Python Library for Tom's Obvious, Minimal Language"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+files = [
+    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
+    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+]
+
+[[package]]
 name = "tqdm"
 version = "4.67.1"
 description = "Fast, Extensible Progress Meter"
@@ -1092,4 +1103,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "e505f066200fe69801ed46af2c3e3d9ceb14989ca318c84c593262a7ca34276a"
+content-hash = "78f08ac20a5ba60ec41642a4066f048951361dd09083a10ddda2371cf2cec126"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1062,6 +1062,20 @@ slack = ["slack-sdk"]
 telegram = ["requests"]
 
 [[package]]
+name = "types-requests"
+version = "2.32.0.20250328"
+description = "Typing stubs for requests"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "types_requests-2.32.0.20250328-py3-none-any.whl", hash = "sha256:72ff80f84b15eb3aa7a8e2625fffb6a93f2ad5a0c20215fc1dcfa61117bcb2a2"},
+    {file = "types_requests-2.32.0.20250328.tar.gz", hash = "sha256:c9e67228ea103bd811c96984fac36ed2ae8da87a36a633964a21f199d60baf32"},
+]
+
+[package.dependencies]
+urllib3 = ">=2"
+
+[[package]]
 name = "types-toml"
 version = "0.10.8.20240310"
 description = "Typing stubs for toml"
@@ -1114,4 +1128,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "816ce8cd17df478c4463f33c4d162e5eefad40295ed0a516e15680bfff9938b5"
+content-hash = "de94c44f165a5354af0904d2ed375a557cfe9c8e4c46cf3e27b2fa8a6c7eaf03"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1062,6 +1062,17 @@ slack = ["slack-sdk"]
 telegram = ["requests"]
 
 [[package]]
+name = "types-toml"
+version = "0.10.8.20240310"
+description = "Typing stubs for toml"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "types-toml-0.10.8.20240310.tar.gz", hash = "sha256:3d41501302972436a6b8b239c850b26689657e25281b48ff0ec06345b8830331"},
+    {file = "types_toml-0.10.8.20240310-py3-none-any.whl", hash = "sha256:627b47775d25fa29977d9c70dc0cbab3f314f32c8d8d0c012f2ef5de7aaec05d"},
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.12.2"
 description = "Backported and Experimental Type Hints for Python 3.8+"
@@ -1103,4 +1114,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "78f08ac20a5ba60ec41642a4066f048951361dd09083a10ddda2371cf2cec126"
+content-hash = "816ce8cd17df478c4463f33c4d162e5eefad40295ed0a516e15680bfff9938b5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ black = "^25.1.0"
 mypy = "^1.15.0"
 toml = "^0.10.2"
 packaging = "^24.2"
+types-toml = "^0.10.8.20240310"
 
 [tool.poetry.scripts]
 commi = "commi.run:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ mypy = "^1.15.0"
 toml = "^0.10.2"
 packaging = "^24.2"
 types-toml = "^0.10.8.20240310"
+requests = "^2.32.3"
+types-requests = "^2.32.0.20250328"
 
 [tool.poetry.scripts]
 commi = "commi.run:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,8 @@ grpcio = "^1.62.0"
 ruff = "^0.9.6"
 black = "^25.1.0"
 mypy = "^1.15.0"
+toml = "^0.10.2"
+packaging = "^24.2"
 
 [tool.poetry.scripts]
 commi = "commi.run:main"

--- a/tests/test_version_update.py
+++ b/tests/test_version_update.py
@@ -1,0 +1,223 @@
+import pytest
+import os
+import json
+import sys
+from unittest.mock import patch, Mock, mock_open, MagicMock
+from datetime import datetime, timedelta
+from commi.cmd import CommiCommands
+
+
+class MockCommiCommands(CommiCommands):
+    """A mock version of CommiCommands that doesn't parse arguments in __init__"""
+    def __init__(self, installed_version="2.2.5", latest_version="v2.3.0"):
+        self.VERSION_CACHE_FILE = os.path.expanduser("~/.commi_version")
+        self.VERSION_CACHE_EXPIRY = timedelta(days=1)
+        self.installed_version = installed_version
+        self.latest_version = latest_version
+        
+        # Create a parser but don't parse args
+        self._setup_parser()
+        
+    def _setup_parser(self):
+        """Setup the argument parser without parsing args"""
+        self.parser = MagicMock()
+        self.args = MagicMock()
+        
+    def get_args(self):
+        """Return mock args"""
+        return self.args
+
+
+@pytest.fixture
+def mock_version_cache():
+    """Fixture to create a mock version cache file."""
+    cache_data = {
+        "version": "v2.3.0",
+        "fetched_at": (datetime.now() - timedelta(hours=2)).isoformat()
+    }
+    
+    with patch("os.path.exists") as mock_exists, \
+         patch("builtins.open", mock_open(read_data=json.dumps(cache_data))) as mock_file:
+        mock_exists.return_value = True
+        yield mock_file
+
+
+def test_argument_parsing_update():
+    """Test the --update argument parsing."""
+    with patch("sys.argv", ["commi", "--update"]), \
+         patch("argparse.ArgumentParser.parse_args", return_value=Mock(update=True)):
+        cmd = MockCommiCommands()
+        cmd.args = Mock(update=True)
+        args = cmd.get_args()
+        assert args.update is True
+
+
+def test_get_installed_version():
+    """Test getting the installed version from pyproject.toml."""
+    mock_pyproject = {
+        "tool": {
+            "poetry": {
+                "version": "2.2.5"
+            }
+        }
+    }
+    
+    with patch("toml.load", return_value=mock_pyproject):
+        cmd = MockCommiCommands()
+        version = cmd.get_installed_version()
+        assert version == "2.2.5"
+
+
+def test_get_latest_version_from_cache(mock_version_cache):
+    """Test getting the latest version from cache."""
+    cmd = MockCommiCommands()
+    version = cmd.get_latest_version()
+    assert version == "v2.3.0"
+
+def test_get_latest_version_from_api():
+    """Test getting the latest version from GitHub API."""
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"tag_name": "v2.3.1"}
+    
+    with patch("os.path.exists", return_value=False), \
+         patch("requests.get", return_value=mock_response), \
+         patch("builtins.open", mock_open()) as mock_file:
+        cmd = MockCommiCommands()
+        version = cmd.get_latest_version()
+        assert version == "v2.3.1"
+        # Verify that write was called (don't check exact number of calls since json.dump makes multiple calls)
+        assert mock_file().write.called
+
+
+def test_get_latest_version_api_error():
+    """Test handling API errors when getting the latest version."""
+    with patch("os.path.exists", return_value=False), \
+         patch("requests.get", side_effect=Exception("API Error")):
+        cmd = MockCommiCommands()
+        version = cmd.get_latest_version()
+        assert version == "0.0.0"  # Default fallback
+
+
+def test_is_update_available():
+    """Test checking if an update is available."""
+    # Test when update is available
+    cmd = MockCommiCommands(installed_version="2.2.5", latest_version="v2.3.0")
+    assert cmd.is_update_available() is True
+    
+    # Test when versions are equal
+    cmd = MockCommiCommands(installed_version="2.3.0", latest_version="v2.3.0")
+    assert cmd.is_update_available() is False
+    
+    # Test when installed version is newer
+    cmd = MockCommiCommands(installed_version="2.4.0", latest_version="v2.3.0")
+    assert cmd.is_update_available() is False
+
+
+def test_update_binary():
+    """Test updating the binary."""
+    with patch("subprocess.run") as mock_run, \
+         patch("subprocess.check_output", return_value=b"/usr/local/bin/commi\n"):
+        
+        cmd = MockCommiCommands(installed_version="2.2.5", latest_version="v2.3.0")
+        result = cmd.update_binary()
+        
+        assert result is True
+        assert mock_run.call_count == 3
+        # Check curl command
+        assert mock_run.call_args_list[0][0][0][0] == "curl"
+        # Check chmod command
+        assert mock_run.call_args_list[1][0][0][0] == "chmod"
+        # Check mv command
+        assert mock_run.call_args_list[2][0][0][0] == "sudo"
+
+
+def test_update_binary_error():
+    """Test handling errors when updating the binary."""
+    with patch("subprocess.run", side_effect=Exception("Update Error")):
+        cmd = MockCommiCommands(installed_version="2.2.5", latest_version="v2.3.0")
+        result = cmd.update_binary()
+        assert result is False
+
+
+def test_help_text_includes_update():
+    """Test that help text includes the update option."""
+    cmd = MockCommiCommands()
+    cmd.parser.format_help.return_value = "--update Update Commi to the latest version"
+    help_text = cmd.parser.format_help()
+    assert "--update" in help_text
+    assert "Update Commi to the latest version" in help_text
+
+def test_main_with_update_flag(caplog):
+    """Test main function with update flag."""
+    from commi.run import main
+    import logging
+    
+    # Set up caplog to capture log messages
+    caplog.set_level(logging.INFO)
+    
+    # We need to patch the specific methods in run.py that use CommiCommands
+    with patch("sys.argv", ["commi", "--update"]), \
+         patch("commi.logs.print_ultron_header"), \
+         patch("commi.run.CommiCommands") as mock_cmd_class:
+        
+        # Setup mock instance
+        mock_instance = Mock()
+        mock_instance.get_args.return_value = Mock(update=True, repo=None, api_key=None)
+        mock_instance.is_update_available.return_value = True
+        mock_instance.installed_version = "2.2.5"
+        mock_instance.latest_version = "v2.3.0"
+        mock_instance.update_binary.return_value = True
+        
+        # Make the mock class return our mock instance
+        mock_cmd_class.return_value = mock_instance
+        
+        # Run main
+        main()
+        
+        # Verify log messages using caplog
+        assert "Update available: 2.2.5 -> v2.3.0" in caplog.text
+        assert mock_instance.update_binary.call_count >= 1
+
+
+def test_main_with_update_notification(caplog):
+    """Test main function with update notification."""
+    from commi.run import main
+    import logging
+    
+    # Set up caplog to capture log messages
+    caplog.set_level(logging.INFO)
+    
+    with patch("sys.argv", ["commi", "--repo", "/mock", "--api-key", "test-key"]), \
+         patch("commi.logs.print_ultron_header"), \
+         patch("commi.run.CommiCommands") as mock_cmd_class, \
+         patch("commi.run.CommitMessageGenerator"), \
+         patch("commi.run.load_configuration", return_value=("test-key", "gemini-1.5-flash")), \
+         patch("commi.run.setup_repo_path", return_value="/mock"), \
+         patch("commi.run.generate_commit_message", return_value="test commit"), \
+         patch("commi.run.has_changes", return_value=False):
+        
+        # Setup mock instance
+        mock_instance = Mock()
+        mock_instance.get_args.return_value = Mock(
+            update=False,
+            repo="/mock",
+            api_key="test-key",
+            cached=False,
+            copy=False,
+            commit=False,
+            co_author=None
+        )
+        mock_instance.is_update_available.return_value = True
+        mock_instance.installed_version = "2.2.5"
+        mock_instance.latest_version = "v2.3.0"
+        
+        # Make the mock class return our mock instance
+        mock_cmd_class.return_value = mock_instance
+        
+        # Run main
+        main()
+        
+        # Verify update notification was shown in the logs using caplog
+        assert "A new version of Commi is available: v2.3.0" in caplog.text
+        assert "Run 'commi --update' to update to the latest version." in caplog.text

--- a/tests/test_version_update.py
+++ b/tests/test_version_update.py
@@ -1,7 +1,6 @@
 import pytest
 import os
 import json
-import sys
 from unittest.mock import patch, Mock, mock_open, MagicMock
 from datetime import datetime, timedelta
 from commi.cmd import CommiCommands

--- a/tests/test_version_update.py
+++ b/tests/test_version_update.py
@@ -9,20 +9,21 @@ from commi.cmd import CommiCommands
 
 class MockCommiCommands(CommiCommands):
     """A mock version of CommiCommands that doesn't parse arguments in __init__"""
+
     def __init__(self, installed_version="2.2.5", latest_version="v2.3.0"):
         self.VERSION_CACHE_FILE = os.path.expanduser("~/.commi_version")
         self.VERSION_CACHE_EXPIRY = timedelta(days=1)
         self.installed_version = installed_version
         self.latest_version = latest_version
-        
+
         # Create a parser but don't parse args
         self._setup_parser()
-        
+
     def _setup_parser(self):
         """Setup the argument parser without parsing args"""
         self.parser = MagicMock()
         self.args = MagicMock()
-        
+
     def get_args(self):
         """Return mock args"""
         return self.args
@@ -33,19 +34,21 @@ def mock_version_cache():
     """Fixture to create a mock version cache file."""
     cache_data = {
         "version": "v2.3.0",
-        "fetched_at": (datetime.now() - timedelta(hours=2)).isoformat()
+        "fetched_at": (datetime.now() - timedelta(hours=2)).isoformat(),
     }
-    
-    with patch("os.path.exists") as mock_exists, \
-         patch("builtins.open", mock_open(read_data=json.dumps(cache_data))) as mock_file:
+
+    with patch("os.path.exists") as mock_exists, patch(
+        "builtins.open", mock_open(read_data=json.dumps(cache_data))
+    ) as mock_file:
         mock_exists.return_value = True
         yield mock_file
 
 
 def test_argument_parsing_update():
     """Test the --update argument parsing."""
-    with patch("sys.argv", ["commi", "--update"]), \
-         patch("argparse.ArgumentParser.parse_args", return_value=Mock(update=True)):
+    with patch("sys.argv", ["commi", "--update"]), patch(
+        "argparse.ArgumentParser.parse_args", return_value=Mock(update=True)
+    ):
         cmd = MockCommiCommands()
         cmd.args = Mock(update=True)
         args = cmd.get_args()
@@ -54,14 +57,8 @@ def test_argument_parsing_update():
 
 def test_get_installed_version():
     """Test getting the installed version from pyproject.toml."""
-    mock_pyproject = {
-        "tool": {
-            "poetry": {
-                "version": "2.2.5"
-            }
-        }
-    }
-    
+    mock_pyproject = {"tool": {"poetry": {"version": "2.2.5"}}}
+
     with patch("toml.load", return_value=mock_pyproject):
         cmd = MockCommiCommands()
         version = cmd.get_installed_version()
@@ -74,15 +71,16 @@ def test_get_latest_version_from_cache(mock_version_cache):
     version = cmd.get_latest_version()
     assert version == "v2.3.0"
 
+
 def test_get_latest_version_from_api():
     """Test getting the latest version from GitHub API."""
     mock_response = Mock()
     mock_response.status_code = 200
     mock_response.json.return_value = {"tag_name": "v2.3.1"}
-    
-    with patch("os.path.exists", return_value=False), \
-         patch("requests.get", return_value=mock_response), \
-         patch("builtins.open", mock_open()) as mock_file:
+
+    with patch("os.path.exists", return_value=False), patch(
+        "requests.get", return_value=mock_response
+    ), patch("builtins.open", mock_open()) as mock_file:
         cmd = MockCommiCommands()
         version = cmd.get_latest_version()
         assert version == "v2.3.1"
@@ -92,8 +90,9 @@ def test_get_latest_version_from_api():
 
 def test_get_latest_version_api_error():
     """Test handling API errors when getting the latest version."""
-    with patch("os.path.exists", return_value=False), \
-         patch("requests.get", side_effect=Exception("API Error")):
+    with patch("os.path.exists", return_value=False), patch(
+        "requests.get", side_effect=Exception("API Error")
+    ):
         cmd = MockCommiCommands()
         version = cmd.get_latest_version()
         assert version == "0.0.0"  # Default fallback
@@ -104,11 +103,11 @@ def test_is_update_available():
     # Test when update is available
     cmd = MockCommiCommands(installed_version="2.2.5", latest_version="v2.3.0")
     assert cmd.is_update_available() is True
-    
+
     # Test when versions are equal
     cmd = MockCommiCommands(installed_version="2.3.0", latest_version="v2.3.0")
     assert cmd.is_update_available() is False
-    
+
     # Test when installed version is newer
     cmd = MockCommiCommands(installed_version="2.4.0", latest_version="v2.3.0")
     assert cmd.is_update_available() is False
@@ -116,12 +115,13 @@ def test_is_update_available():
 
 def test_update_binary():
     """Test updating the binary."""
-    with patch("subprocess.run") as mock_run, \
-         patch("subprocess.check_output", return_value=b"/usr/local/bin/commi\n"):
-        
+    with patch("subprocess.run") as mock_run, patch(
+        "subprocess.check_output", return_value=b"/usr/local/bin/commi\n"
+    ):
+
         cmd = MockCommiCommands(installed_version="2.2.5", latest_version="v2.3.0")
         result = cmd.update_binary()
-        
+
         assert result is True
         assert mock_run.call_count == 3
         # Check curl command
@@ -148,19 +148,20 @@ def test_help_text_includes_update():
     assert "--update" in help_text
     assert "Update Commi to the latest version" in help_text
 
+
 def test_main_with_update_flag(caplog):
     """Test main function with update flag."""
     from commi.run import main
     import logging
-    
+
     # Set up caplog to capture log messages
     caplog.set_level(logging.INFO)
-    
+
     # We need to patch the specific methods in run.py that use CommiCommands
-    with patch("sys.argv", ["commi", "--update"]), \
-         patch("commi.logs.print_ultron_header"), \
-         patch("commi.run.CommiCommands") as mock_cmd_class:
-        
+    with patch("sys.argv", ["commi", "--update"]), patch(
+        "commi.logs.print_ultron_header"
+    ), patch("commi.run.CommiCommands") as mock_cmd_class:
+
         # Setup mock instance
         mock_instance = Mock()
         mock_instance.get_args.return_value = Mock(update=True, repo=None, api_key=None)
@@ -168,13 +169,13 @@ def test_main_with_update_flag(caplog):
         mock_instance.installed_version = "2.2.5"
         mock_instance.latest_version = "v2.3.0"
         mock_instance.update_binary.return_value = True
-        
+
         # Make the mock class return our mock instance
         mock_cmd_class.return_value = mock_instance
-        
+
         # Run main
         main()
-        
+
         # Verify log messages using caplog
         assert "Update available: 2.2.5 -> v2.3.0" in caplog.text
         assert mock_instance.update_binary.call_count >= 1
@@ -184,19 +185,26 @@ def test_main_with_update_notification(caplog):
     """Test main function with update notification."""
     from commi.run import main
     import logging
-    
+
     # Set up caplog to capture log messages
     caplog.set_level(logging.INFO)
-    
-    with patch("sys.argv", ["commi", "--repo", "/mock", "--api-key", "test-key"]), \
-         patch("commi.logs.print_ultron_header"), \
-         patch("commi.run.CommiCommands") as mock_cmd_class, \
-         patch("commi.run.CommitMessageGenerator"), \
-         patch("commi.run.load_configuration", return_value=("test-key", "gemini-1.5-flash")), \
-         patch("commi.run.setup_repo_path", return_value="/mock"), \
-         patch("commi.run.generate_commit_message", return_value="test commit"), \
-         patch("commi.run.has_changes", return_value=False):
-        
+
+    with patch(
+        "sys.argv", ["commi", "--repo", "/mock", "--api-key", "test-key"]
+    ), patch("commi.logs.print_ultron_header"), patch(
+        "commi.run.CommiCommands"
+    ) as mock_cmd_class, patch(
+        "commi.run.CommitMessageGenerator"
+    ), patch(
+        "commi.run.load_configuration", return_value=("test-key", "gemini-1.5-flash")
+    ), patch(
+        "commi.run.setup_repo_path", return_value="/mock"
+    ), patch(
+        "commi.run.generate_commit_message", return_value="test commit"
+    ), patch(
+        "commi.run.has_changes", return_value=False
+    ):
+
         # Setup mock instance
         mock_instance = Mock()
         mock_instance.get_args.return_value = Mock(
@@ -206,18 +214,18 @@ def test_main_with_update_notification(caplog):
             cached=False,
             copy=False,
             commit=False,
-            co_author=None
+            co_author=None,
         )
         mock_instance.is_update_available.return_value = True
         mock_instance.installed_version = "2.2.5"
         mock_instance.latest_version = "v2.3.0"
-        
+
         # Make the mock class return our mock instance
         mock_cmd_class.return_value = mock_instance
-        
+
         # Run main
         main()
-        
+
         # Verify update notification was shown in the logs using caplog
         assert "A new version of Commi is available: v2.3.0" in caplog.text
         assert "Run 'commi --update' to update to the latest version." in caplog.text


### PR DESCRIPTION
### Changes 

- Support `--version` flag to stdout the current installed bin version
- Support a new hint message if the installed version is outdated
- Support `--update` flag to update the commi binary by installing it from the latest release
- Support script to install the newly released version `if latest version`
- Write unit-tests for the new added feature

### Related issues 

- https://github.com/Mahmoud-Emad/commi/issues/9